### PR TITLE
Expand the FAQ's table of contents

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,3 +1,9 @@
 # Summary
 
 [CHERI Frequently Asked Questions](cover/README.md)
+- [General](QUESTIONS.md#General)
+- [Operating systems](QUESTIONS.md#Operating-systems)
+    - [CheriBSD](QUESTIONS.md#CheriBSD)
+- [Software porting](QUESTIONS.md#Software-porting)
+- [Compartmentalization](QUESTIONS.md#Compartmentalization)
+- [Community](QUESTIONS.md#Community)


### PR DESCRIPTION
This PR extends the navigation pane, or table of contents, via the additional interlinks in `src/SUMMARY.md`.