### PR TITLE
Add questions and move the CheriBSD section

### DIFF
--- a/src/QUESTIONS.md
+++ b/src/QUESTIONS.md
@@ -112,6 +112,18 @@ If you intend to work with code that runs on UNIX-like operating systems, we
 recommend you to start with CheriBSD.
 
 
+### How do I get started with CheriBSD on Morello?
+
+Follow the
+[Getting Started with CheriBSD guide](https://ctsrd-cheri.github.io/cheribsd-getting-started/)
+and do not skip any section.
+
+The guide has been structured to make you aware of actions you should take
+before trying to use CheriBSD.
+Of critical importance, you should upgrade your Morello board firmware before
+installing CheriBSD.
+
+
 ## Software porting
 
 
@@ -324,18 +336,6 @@ wiki page for `print` command output formats.
 ## CheriBSD
 
 
-### How do I get started with CheriBSD on Morello?
-
-Follow the
-[Getting Started with CheriBSD guide](https://ctsrd-cheri.github.io/cheribsd-getting-started/)
-and do not skip any section.
-
-The guide has been structured to make you aware of actions you should take
-before trying to use CheriBSD.
-Of critical importance, you should upgrade your Morello board firmware before
-installing CheriBSD.
-
-
 ### How can I upgrade CheriBSD?
 
 Currently, there are no binary upgrades for CheriBSD.
@@ -383,7 +383,9 @@ See the
 [Cornucopia tutorial](https://github.com/CTSRD-CHERI/cheripedia/wiki/HOWTO:-Use-Cornucopia-with-the-22.12-CheriBSD-Release)
 to read more how to use it.
 
-
+<!--
+NOTE: When changing this title, remember to update references in this document.
+-->
 ### How can I switch to another CheriBSD kernel (e.g., a pure-capability kernel)?
 
 Use one of the following methods:

--- a/src/QUESTIONS.md
+++ b/src/QUESTIONS.md
@@ -2,16 +2,12 @@
 
 ### What is CHERI?
 
-CHERI (Capability Hardware Enhanced RISC Instructions) is an international research project to revisit the fundamental security assumptions in both hardware and software. [An Introduction to CHERI](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-941.pdf) provides a high-level overview of the project. It builds upon an earlier fruit-themed project known as [BERI](https://www.cl.cam.ac.uk/research/security/ctsrd/beri/).
+[CHERI](https://www.cl.cam.ac.uk/research/security/ctsrd/cheri/) (Capability Hardware Enhanced RISC Instructions) is a joint research project by SRI International and the University of Cambridge to revisit fundamental design choices in hardware and software to dramatically improve system security. [An Introduction to CHERI](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-941.pdf) provides a high-level introduction to CHERI.
 
 
 ### What types of threat has CHERI been designed to prevent?
 
-CHERI has been developed to have two applications: memory-safe C/C++ and software compartmentalization.
-
-Memory-safe C/C++ includes spatial, referential, and temporal protection mechanisms, defending against both vulnerabilities and exploitation techniques. Out-of-bound writes and reads, i.e. [buffer overflows](https://en.wikipedia.org/wiki/Buffer_overflow) and over-reads, are but two examples of spatial access vulnerability that can be avoided. Exploit chains and techniques, such as the [confused deputy problem](https://en.wikipedia.org/wiki/Confused_deputy_problem), can be prevented directly.
-
-[Compartmentalizations](https://www.cl.cam.ac.uk/research/security/ctsrd/cheri/cheri-compartmentalization.html) are fine-grained models that sandbox a given application, limiting the likelihood of it crashing and resulting in a denial of service if attacked. Such a compartment therefore provides resilience to a variety of applications or services that need to demonstrate high-availability or -reliability, e.g. image processors. Where malicious payloads would ordinarily crash or compromise the image processor, the compartmentalized application would simply render the standard icon for missing images in the browser instead.
+CHERI enables fine-grained memory protection (e.g. to prevent out-of-bounds and use-after-free bugs) and highly scalable software compartmentalization (e.g. to mitigate future or unknown vulnerabilities in third-party software).
 
 
 ### What CHERI-extended hardware is available to use?
@@ -54,24 +50,21 @@ website and follow the instructions there.
    * For CHERI-RISC-V: `cheribuild.py run-riscv64-purecap -d`
 
 
-### Where are the cheribuild.py images and builds stored?
+### Where are cheribuild.py images and build files stored?
 
-By default, any images will reside in `$HOME/cheri/output` and builds in `$HOME/cheri/build`.
-
-
-### Can I build targets from specific branches using cheribuild.py?
-
-Yes. Once executed, the cheribuild.py script will create a `$HOME/cheri` directory to contain all of the repositories, builds, and configuration needed. If you change to the specific directory for your target, you will then be able to check out the correct branch and run `./cheribuild.py` against it.
-```bash
-cd $HOME/cheri/cheribsd
-git checkout releng/22.12
-
-cd $HOME/cheribuild
-./cheribuild.py cheribsd-morello-purecap
-```
+By default, images built by `cheribuild.py` are stored in `$HOME/cheri/output` and build files in `$HOME/cheri/build`.
 
 
-### Can I develop bare-metal applications for Morello?
+### Can I build a custom CheriBSD branch using cheribuild.py?
+
+Yes. `cheribuild.py` implements several flags to allow you to build multiple CheriBSD branches and store the results separately:
+* `--cheribsd-<target>/source-directory /path/to/your/branch` to specify a custom branch's source code directory.
+* `--cheribsd-<target>/build-directory /path/to/your/build` to specify where build files should be stored.
+* `--cheribsd-<target>/install-directory /path/to/your/rootfs` to specify where root filesystem files should be installed.
+* `--disk-image-<target>/path /path/to/your/image.img` to specify where a disk image should be stored.
+
+
+### Can I develop bare-metal applications for Arm Morello?
 
 Yes. Arm have created an example of a [bare-metal application](https://git.morello-project.org/morello/docs/-/blob/morello/mainline/common/standalone-baremetal-readme.rst) for the board.
 
@@ -117,95 +110,6 @@ It also provides a large number of pre-compiled third-party software
 dependencies that you can simply install with package managers for your project.
 If you intend to work with code that runs on UNIX-like operating systems, we
 recommend you to start with CheriBSD.
-
-
-## CheriBSD
-
-
-### How do I get started with CheriBSD on Morello?
-
-Follow the
-[Getting Started with CheriBSD guide](https://ctsrd-cheri.github.io/cheribsd-getting-started/)
-and do not skip any section.
-
-The guide has been structured to make you aware of actions you should take
-before trying to use CheriBSD.
-Of critical importance, you should upgrade your Morello board firmware before
-installing CheriBSD.
-
-
-### How can I upgrade CheriBSD?
-
-Currently, there are no binary upgrades for CheriBSD.
-
-The only way to upgrade a CheriBSD host is to build and install CheriBSD from
-source code.
-See the
-[wiki page](https://github.com/CTSRD-CHERI/cheripedia/wiki/HOWTO:-Build-CheriBSD-natively-on-Morello)
-for instructions how to do this.
-Note that we cannot guarantee stability when upgrading CheriBSD and it is
-important to make sure you can recover your data if an upgrade fails.
-
-
-### How can I build CheriBSD from source code?
-
-You have two choices:
-* Build and install CheriBSD natively on Arm Morello using
-[these instructions](https://github.com/CTSRD-CHERI/cheripedia/wiki/HOWTO:-Build-CheriBSD-natively-on-Morello)
-
-* Cross-compile (on FreeBSD, macOS or Linux) CheriBSD for CHERI-RISC-V or Arm Morello using
-[cheribuild](https://github.com/CTSRD-CHERI/cheribuild)
-
-
-### Does CheriBSD implement spatial safety (e.g., to prevent out-of-bounds bugs)?
-
-The official CheriBSD release runs basic programs and libraries compiled
-for the pure-capability ABI and a hybrid kernel.
-
-It also includes a pure-capability kernel in
-`/boot/kernel.GENERIC-MORELLO-PURECAP`.
-See
-[these instructions](/#how-can-i-switch-to-another-cheribsd-kernel-eg-a-pure-capability-kernel)
-to find out how to do that.
-
-
-### Does CheriBSD implement temporal safety (e.g., to prevent use-after-free bugs)?
-
-Currently, the official CheriBSD release does not include temporal safety
-mechanisms.
-This feature (also known as Cornucopia in CheriBSD) is scheduled for a future
-release and can be used today by installing a Cornucopia-enabled kernel and
-revocation-aware memory allocators.
-
-See the
-[Cornucopia tutorial](https://github.com/CTSRD-CHERI/cheripedia/wiki/HOWTO:-Use-Cornucopia-with-the-22.12-CheriBSD-Release)
-to read more how to use it.
-
-
-### How can I switch to another CheriBSD kernel (e.g., a pure-capability kernel)?
-
-Use one of the following methods:
-* Run `nextboot -k KERNCONF`
-
-  See [nextboot(8)](https://man.cheribsd.org/cgi-bin/man.cgi/nextboot.8) for more
-  details.
-
-* Add `kernel="KERNCONF"` to `/boot/loader.conf`
-
-  See [loader.conf(5)](https://man.cheribsd.org/cgi-bin/man.cgi/loader.conf.5) for
-  more details.
-
-* In a boot loader, press `5` multiple times to select `KERNCONF`
-
-`KERNCONF` is a name of a directory in the `/boot` directory with a kernel
-(e.g., `kernel.GENERIC-MORELLO-PURECAP`) that corresponds to a kernel
-configuration file from CheriBSD source code (e.g.,
-[GENERIC-MORELLO-PURECAP](https://github.com/CTSRD-CHERI/cheribsd/blob/main/sys/arm64/conf/GENERIC-MORELLO-PURECAP)).
-
-
-### Is there any IDE for CheriBSD?
-
-No. The closest to it is Kate Editor but it is still far from an actual IDE.
 
 
 ## Software porting
@@ -353,7 +257,7 @@ You can list all available software on CheriBSD with `pkg64c rquery %n` and
 Alternatively, you can search for a specific package using
 `pkg64c search <pattern>` and `pkg64 search <pattern>`.
 
-If you simply require a list of packages independently of CheriBSD, there are tarballs on [pkg.cheribsd.org](https://pkg.cheribsd.org) that contain JSON-formatted data. To generate a list of CHERI packages with specific fields, you can use `curl`, `tar`, and `jq`:
+If you simply require a list of packages independently of CheriBSD, there are browsable HTML lists of the ports for both architectures: [AArch64](https://pkg.cheribsd.org/CheriBSD:20220828:aarch64.html) (hybrid) and [AArch64c](https://pkg.cheribsd.org/CheriBSD:20220828:aarch64c.html) (CHERI). In addition, there are tarballs on [pkg.cheribsd.org](https://pkg.cheribsd.org) that contain the raw JSON-formatted package data. To generate a list of CHERI packages with specific fields, you can use `curl`, `tar`, and `jq`:
 ```bash
 curl -O https://pkg.cheribsd.org/CheriBSD:20220828:aarch64c/packagesite.txz
 tar xf *.txz
@@ -415,6 +319,95 @@ wiki page for `print` command output formats.
   [cocalls branch](https://github.com/CTSRD-CHERI/cheribsd/tree/cocalls).
 
   There are plans to make this model available for Morello as well.
+
+
+## CheriBSD
+
+
+### How do I get started with CheriBSD on Morello?
+
+Follow the
+[Getting Started with CheriBSD guide](https://ctsrd-cheri.github.io/cheribsd-getting-started/)
+and do not skip any section.
+
+The guide has been structured to make you aware of actions you should take
+before trying to use CheriBSD.
+Of critical importance, you should upgrade your Morello board firmware before
+installing CheriBSD.
+
+
+### How can I upgrade CheriBSD?
+
+Currently, there are no binary upgrades for CheriBSD.
+
+The only way to upgrade a CheriBSD host is to build and install CheriBSD from
+source code.
+See the
+[wiki page](https://github.com/CTSRD-CHERI/cheripedia/wiki/HOWTO:-Build-CheriBSD-natively-on-Morello)
+for instructions how to do this.
+Note that we cannot guarantee stability when upgrading CheriBSD and it is
+important to make sure you can recover your data if an upgrade fails.
+
+
+### How can I build CheriBSD from source code?
+
+You have two choices:
+* Build and install CheriBSD natively on Arm Morello using
+[these instructions](https://github.com/CTSRD-CHERI/cheripedia/wiki/HOWTO:-Build-CheriBSD-natively-on-Morello)
+
+* Cross-compile (on FreeBSD, macOS or Linux) CheriBSD for CHERI-RISC-V or Arm Morello using
+[cheribuild](https://github.com/CTSRD-CHERI/cheribuild)
+
+
+### Does CheriBSD implement spatial safety (e.g., to prevent out-of-bounds bugs)?
+
+The official CheriBSD release runs basic programs and libraries compiled
+for the pure-capability ABI and a hybrid kernel.
+
+It also includes a pure-capability kernel in
+`/boot/kernel.GENERIC-MORELLO-PURECAP`.
+See
+[these instructions](/#how-can-i-switch-to-another-cheribsd-kernel-eg-a-pure-capability-kernel)
+to find out how to do that.
+
+
+### Does CheriBSD implement temporal safety (e.g., to prevent use-after-free bugs)?
+
+Currently, the official CheriBSD release does not include temporal safety
+mechanisms.
+This feature (also known as Cornucopia in CheriBSD) is scheduled for a future
+release and can be used today by installing a Cornucopia-enabled kernel and
+revocation-aware memory allocators.
+
+See the
+[Cornucopia tutorial](https://github.com/CTSRD-CHERI/cheripedia/wiki/HOWTO:-Use-Cornucopia-with-the-22.12-CheriBSD-Release)
+to read more how to use it.
+
+
+### How can I switch to another CheriBSD kernel (e.g., a pure-capability kernel)?
+
+Use one of the following methods:
+* Run `nextboot -k KERNCONF`
+
+  See [nextboot(8)](https://man.cheribsd.org/cgi-bin/man.cgi/nextboot.8) for more
+  details.
+
+* Add `kernel="KERNCONF"` to `/boot/loader.conf`
+
+  See [loader.conf(5)](https://man.cheribsd.org/cgi-bin/man.cgi/loader.conf.5) for
+  more details.
+
+* In a boot loader, press `5` multiple times to select `KERNCONF`
+
+`KERNCONF` is a name of a directory in the `/boot` directory with a kernel
+(e.g., `kernel.GENERIC-MORELLO-PURECAP`) that corresponds to a kernel
+configuration file from CheriBSD source code (e.g.,
+[GENERIC-MORELLO-PURECAP](https://github.com/CTSRD-CHERI/cheribsd/blob/main/sys/arm64/conf/GENERIC-MORELLO-PURECAP)).
+
+
+### Is there any IDE for CheriBSD?
+
+No. The closest to it is Kate Editor but it is still far from an actual IDE.
 
 
 ## Community

--- a/src/QUESTIONS.md
+++ b/src/QUESTIONS.md
@@ -64,9 +64,9 @@ Yes. `cheribuild.py` implements several flags to allow you to build multiple Che
 * `--disk-image-<target>/path /path/to/your/image.img` to specify where a disk image should be stored.
 
 
-### Can I develop bare-metal applications for Arm Morello?
+### Can I develop baremetal applications for Arm Morello?
 
-Yes. Arm have created an example of a [bare-metal application](https://git.morello-project.org/morello/docs/-/blob/morello/mainline/common/standalone-baremetal-readme.rst) for the board.
+See this [example](https://git.morello-project.org/morello/docs/-/blob/morello/mainline/common/standalone-baremetal-readme.rst) application.
 
 
 ## Operating systems
@@ -269,16 +269,7 @@ You can list all available software on CheriBSD with `pkg64c rquery %n` and
 Alternatively, you can search for a specific package using
 `pkg64c search <pattern>` and `pkg64 search <pattern>`.
 
-If you simply require a list of packages independently of CheriBSD, there are browsable HTML lists of the ports for both architectures: [AArch64](https://pkg.cheribsd.org/CheriBSD:20220828:aarch64.html) (hybrid) and [AArch64c](https://pkg.cheribsd.org/CheriBSD:20220828:aarch64c.html) (CHERI). In addition, there are tarballs on [pkg.cheribsd.org](https://pkg.cheribsd.org) that contain the raw JSON-formatted package data. To generate a list of CHERI packages with specific fields, you can use `curl`, `tar`, and `jq`:
-```bash
-curl -O https://pkg.cheribsd.org/CheriBSD:20220828:aarch64c/packagesite.txz
-tar xf *.txz
-jq -j '.name," (",.version,"; ",.abi,"): ",.www,"\n"' *.yaml | sort -uf > aarch64c.txt
-```
-To create a similar list of hybrid packages, use the following instead:
-```bash
-curl -O https://pkg.cheribsd.org/CheriBSD:20220828:aarch64/packagesite.txz
-```
+You can browse CheriABI and hybrid ABI package repositories at [pkg.cheribsd.org](https://pkg.cheribsd.org/).
 
 The packages are built using
 [CheriBSD ports](https://github.com/CTSRD-CHERI/cheribsd-ports),

--- a/src/QUESTIONS.md
+++ b/src/QUESTIONS.md
@@ -2,8 +2,16 @@
 
 ### What is CHERI?
 
-See
-[An Introduction to CHERI](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-941.pdf).
+CHERI (Capability Hardware Enhanced RISC Instructions) is an international research project to revisit the fundamental security assumptions in both hardware and software. [An Introduction to CHERI](https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-941.pdf) provides a high-level overview of the project. It builds upon an earlier fruit-themed project known as [BERI](https://www.cl.cam.ac.uk/research/security/ctsrd/beri/).
+
+
+### What types of threat has CHERI been designed to prevent?
+
+CHERI has been developed to have two applications: memory-safe C/C++ and software compartmentalization.
+
+Memory-safe C/C++ includes spatial, referential, and temporal protection mechanisms, defending against both vulnerabilities and exploitation techniques. Out-of-bound writes and reads, i.e. [buffer overflows](https://en.wikipedia.org/wiki/Buffer_overflow) and over-reads, are but two examples of spatial access vulnerability that can be avoided. Exploit chains and techniques, such as the [confused deputy problem](https://en.wikipedia.org/wiki/Confused_deputy_problem), can be prevented directly.
+
+[Compartmentalizations](https://www.cl.cam.ac.uk/research/security/ctsrd/cheri/cheri-compartmentalization.html) are fine-grained models that sandbox a given application, limiting the likelihood of it crashing and resulting in a denial of service if attacked. Such a compartment therefore provides resilience to a variety of applications or services that need to demonstrate high-availability or -reliability, e.g. image processors. Where malicious payloads would ordinarily crash or compromise the image processor, the compartmentalized application would simply render the standard icon for missing images in the browser instead.
 
 
 ### What CHERI-extended hardware is available to use?

--- a/src/QUESTIONS.md
+++ b/src/QUESTIONS.md
@@ -46,6 +46,28 @@ website and follow the instructions there.
    * For CHERI-RISC-V: `cheribuild.py run-riscv64-purecap -d`
 
 
+### Where are the cheribuild.py images and builds stored?
+
+By default, any images will reside in `$HOME/cheri/output` and builds in `$HOME/cheri/build`.
+
+
+### Can I build targets from specific branches using cheribuild.py?
+
+Yes. Once executed, the cheribuild.py script will create a `$HOME/cheri` directory to contain all of the repositories, builds, and configuration needed. If you change to the specific directory for your target, you will then be able to check out the correct branch and run `./cheribuild.py` against it.
+```bash
+cd $HOME/cheri/cheribsd
+git checkout releng/22.12
+
+cd $HOME/cheribuild
+./cheribuild.py cheribsd-morello-purecap
+```
+
+
+### Can I develop bare-metal applications for Morello?
+
+Yes. Arm have created an example of a [bare-metal application](https://git.morello-project.org/morello/docs/-/blob/morello/mainline/common/standalone-baremetal-readme.rst) for the board.
+
+
 ## Operating systems
 
 
@@ -89,6 +111,9 @@ If you intend to work with code that runs on UNIX-like operating systems, we
 recommend you to start with CheriBSD.
 
 
+## CheriBSD
+
+
 ### How do I get started with CheriBSD on Morello?
 
 Follow the
@@ -99,6 +124,80 @@ The guide has been structured to make you aware of actions you should take
 before trying to use CheriBSD.
 Of critical importance, you should upgrade your Morello board firmware before
 installing CheriBSD.
+
+
+### How can I upgrade CheriBSD?
+
+Currently, there are no binary upgrades for CheriBSD.
+
+The only way to upgrade a CheriBSD host is to build and install CheriBSD from
+source code.
+See the
+[wiki page](https://github.com/CTSRD-CHERI/cheripedia/wiki/HOWTO:-Build-CheriBSD-natively-on-Morello)
+for instructions how to do this.
+Note that we cannot guarantee stability when upgrading CheriBSD and it is
+important to make sure you can recover your data if an upgrade fails.
+
+
+### How can I build CheriBSD from source code?
+
+You have two choices:
+* Build and install CheriBSD natively on Arm Morello using
+[these instructions](https://github.com/CTSRD-CHERI/cheripedia/wiki/HOWTO:-Build-CheriBSD-natively-on-Morello)
+
+* Cross-compile (on FreeBSD, macOS or Linux) CheriBSD for CHERI-RISC-V or Arm Morello using
+[cheribuild](https://github.com/CTSRD-CHERI/cheribuild)
+
+
+### Does CheriBSD implement spatial safety (e.g., to prevent out-of-bounds bugs)?
+
+The official CheriBSD release runs basic programs and libraries compiled
+for the pure-capability ABI and a hybrid kernel.
+
+It also includes a pure-capability kernel in
+`/boot/kernel.GENERIC-MORELLO-PURECAP`.
+See
+[these instructions](/#how-can-i-switch-to-another-cheribsd-kernel-eg-a-pure-capability-kernel)
+to find out how to do that.
+
+
+### Does CheriBSD implement temporal safety (e.g., to prevent use-after-free bugs)?
+
+Currently, the official CheriBSD release does not include temporal safety
+mechanisms.
+This feature (also known as Cornucopia in CheriBSD) is scheduled for a future
+release and can be used today by installing a Cornucopia-enabled kernel and
+revocation-aware memory allocators.
+
+See the
+[Cornucopia tutorial](https://github.com/CTSRD-CHERI/cheripedia/wiki/HOWTO:-Use-Cornucopia-with-the-22.12-CheriBSD-Release)
+to read more how to use it.
+
+
+### How can I switch to another CheriBSD kernel (e.g., a pure-capability kernel)?
+
+Use one of the following methods:
+* Run `nextboot -k KERNCONF`
+
+  See [nextboot(8)](https://man.cheribsd.org/cgi-bin/man.cgi/nextboot.8) for more
+  details.
+
+* Add `kernel="KERNCONF"` to `/boot/loader.conf`
+
+  See [loader.conf(5)](https://man.cheribsd.org/cgi-bin/man.cgi/loader.conf.5) for
+  more details.
+
+* In a boot loader, press `5` multiple times to select `KERNCONF`
+
+`KERNCONF` is a name of a directory in the `/boot` directory with a kernel
+(e.g., `kernel.GENERIC-MORELLO-PURECAP`) that corresponds to a kernel
+configuration file from CheriBSD source code (e.g.,
+[GENERIC-MORELLO-PURECAP](https://github.com/CTSRD-CHERI/cheribsd/blob/main/sys/arm64/conf/GENERIC-MORELLO-PURECAP)).
+
+
+### Is there any IDE for CheriBSD?
+
+No. The closest to it is Kate Editor but it is still far from an actual IDE.
 
 
 ## Software porting
@@ -246,6 +345,17 @@ You can list all available software on CheriBSD with `pkg64c rquery %n` and
 Alternatively, you can search for a specific package using
 `pkg64c search <pattern>` and `pkg64 search <pattern>`.
 
+If you simply require a list of packages indendently of CheriBSD, there are tarballs on [pkg.cheribsd.org](https://pkg.cheribsd.org) that contain JSON-formatted data. To generate a list of CHERI packages with specific fields, you can use `curl`, `tar`, and `jq`:
+```bash
+curl -O https://pkg.cheribsd.org/CheriBSD:20220828:aarch64c/packagesite.txz
+tar xf *.txz
+jq -j '.name," (",.version,"; ",.abi,"): ",.www,"\n"' *.yaml | sort -uf > aarch64c.txt
+```
+To create a similar list of hybrid packages, use the following instead:
+```bash
+curl -O https://pkg.cheribsd.org/CheriBSD:20220828:aarch64/packagesite.txz
+```
+
 The packages are built using
 [CheriBSD ports](https://github.com/CTSRD-CHERI/cheribsd-ports),
 a fork of
@@ -297,86 +407,6 @@ wiki page for `print` command output formats.
   [cocalls branch](https://github.com/CTSRD-CHERI/cheribsd/tree/cocalls).
 
   There are plans to make this model available for Morello as well.
-
-
-## CheriBSD
-
-
-### How can I upgrade CheriBSD?
-
-Currently, there are no binary upgrades for CheriBSD.
-
-The only way to upgrade a CheriBSD host is to build and install CheriBSD from
-source code.
-See the
-[wiki page](https://github.com/CTSRD-CHERI/cheripedia/wiki/HOWTO:-Build-CheriBSD-natively-on-Morello)
-for instructions how to do this.
-Note that we cannot guarantee stability when upgrading CheriBSD and it is
-important to make sure you can recover your data if an upgrade fails.
-
-
-### How can I build CheriBSD from source code?
-
-You have two choices:
-* Build and install CheriBSD natively on Arm Morello using
-[these instructions](https://github.com/CTSRD-CHERI/cheripedia/wiki/HOWTO:-Build-CheriBSD-natively-on-Morello)
-
-* Cross-compile (on FreeBSD, macOS or Linux) CheriBSD for CHERI-RISC-V or Arm Morello using
-[cheribuild](https://github.com/CTSRD-CHERI/cheribuild)
-
-
-### Does CheriBSD implement spatial safety (e.g., to prevent out-of-bounds bugs)?
-
-The official CheriBSD release runs basic programs and libraries compiled
-for the pure-capability ABI and a hybrid kernel.
-
-It also includes a pure-capability kernel in
-`/boot/kernel.GENERIC-MORELLO-PURECAP`.
-See
-[these instructions](/#how-can-i-switch-to-another-cheribsd-kernel-eg-a-pure-capability-kernel)
-to find out how to do that.
-
-
-### Does CheriBSD implement temporal safety (e.g., to prevent use-after-free bugs)?
-
-Currently, the official CheriBSD release does not include temporal safety
-mechanisms.
-This feature (also known as Cornucopia in CheriBSD) is scheduled for a future
-release and can be used today by installing a Cornucopia-enabled kernel and
-revocation-aware memory allocators.
-
-See the
-[Cornucopia tutorial](https://github.com/CTSRD-CHERI/cheripedia/wiki/HOWTO:-Use-Cornucopia-with-the-22.12-CheriBSD-Release)
-to read more how to use it.
-
-
-<!--
-NOTE: When changing this title, remember to update references in this document.
--->
-### How can I switch to another CheriBSD kernel (e.g., a pure-capability kernel)?
-
-Use one of the following methods:
-* Run `nextboot -k KERNCONF`
-
-  See [nextboot(8)](https://man.cheribsd.org/cgi-bin/man.cgi/nextboot.8) for more
-  details.
-
-* Add `kernel="KERNCONF"` to `/boot/loader.conf`
-
-  See [loader.conf(5)](https://man.cheribsd.org/cgi-bin/man.cgi/loader.conf.5) for
-  more details.
-
-* In a boot loader, press `5` multiple times to select `KERNCONF`
-
-`KERNCONF` is a name of a directory in the `/boot` directory with a kernel
-(e.g., `kernel.GENERIC-MORELLO-PURECAP`) that corresponds to a kernel
-configuration file from CheriBSD source code (e.g.,
-[GENERIC-MORELLO-PURECAP](https://github.com/CTSRD-CHERI/cheribsd/blob/main/sys/arm64/conf/GENERIC-MORELLO-PURECAP)).
-
-
-### Is there any IDE for CheriBSD?
-
-No. The closest to it is Kate Editor but it is still far from an actual IDE.
 
 
 ## Community

--- a/src/QUESTIONS.md
+++ b/src/QUESTIONS.md
@@ -345,7 +345,7 @@ You can list all available software on CheriBSD with `pkg64c rquery %n` and
 Alternatively, you can search for a specific package using
 `pkg64c search <pattern>` and `pkg64 search <pattern>`.
 
-If you simply require a list of packages indendently of CheriBSD, there are tarballs on [pkg.cheribsd.org](https://pkg.cheribsd.org) that contain JSON-formatted data. To generate a list of CHERI packages with specific fields, you can use `curl`, `tar`, and `jq`:
+If you simply require a list of packages independently of CheriBSD, there are tarballs on [pkg.cheribsd.org](https://pkg.cheribsd.org) that contain JSON-formatted data. To generate a list of CHERI packages with specific fields, you can use `curl`, `tar`, and `jq`:
 ```bash
 curl -O https://pkg.cheribsd.org/CheriBSD:20220828:aarch64c/packagesite.txz
 tar xf *.txz


### PR DESCRIPTION
As part of the introductory set of questions, this PR expands the CHERI acronym, references BERI to explain the fruit connection, and provides context on the main threats being addressed. Other questions, such as those relating to where the tooling places builds and images, should avoid confusion for developers. Moving the section on CheriBSD to be earlier in the list ought to also help keep relevant subjects together.